### PR TITLE
chore: bump rollup and missing pinned dep

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,7 +20,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "node": ">=20"
       },
       "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "*"
+        "@rollup/rollup-linux-x64-gnu": "^4.45.0"
       }
     },
     "node_modules/@actions/artifact": {
@@ -2401,9 +2401,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.44.0.tgz",
-      "integrity": "sha512-iUVJc3c0o8l9Sa/qlDL2Z9UP92UZZW1+EmQ4xfjTc1akr0iUFZNfxrXJ/R1T90h/ILm9iXEY6+iPrmYB3pXKjw==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.45.0.tgz",
+      "integrity": "sha512-XZdD3fEEQcwG2KrJDdEQu7NrHonPxxaV0/w2HpvINBdcqebz1aL+0vM2WFJq4DeiAVT6F5SUQas65HY5JDqoPw==",
       "cpu": [
         "x64"
       ],
@@ -7546,6 +7546,20 @@
         "@rollup/rollup-win32-x64-msvc": "4.44.0",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.44.0.tgz",
+      "integrity": "sha512-iUVJc3c0o8l9Sa/qlDL2Z9UP92UZZW1+EmQ4xfjTc1akr0iUFZNfxrXJ/R1T90h/ILm9iXEY6+iPrmYB3pXKjw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
     "typescript": "^5.8.3"
   },
   "optionalDependencies": {
-    "@rollup/rollup-linux-x64-gnu": "*"
+    "@rollup/rollup-linux-x64-gnu": "^4.45.0"
   }
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 INDUSTRIA DE DISEÑO TEXTIL S.A. (INDITEX S.A.)

SPDX-License-Identifier: Apache-2.0
-->

<!-- markdownlint-disable first-line-heading -->

## Summary

Pin missing workflow action and bump rollup to close #18 (released this Saturday in between this work).

## Checklist

- [x] Commits are **signed** (`git commit -S`)
- [x] Commit messages follow **Conventional Commits**
- [x] Documentation has been updated (if needed)
- [x] I have read and agree to the project’s [Code of Conduct](../CODE_OF_CONDUCT.md)
- [ ] ~~I have signed the [Contributor License Agreement (CLA)](../CONTRIBUTING.md)~~ _not applicable_

